### PR TITLE
Fix KV cache concat trimming for multi-token updates

### DIFF
--- a/tests/test_bugfix_kvcache_optional.py
+++ b/tests/test_bugfix_kvcache_optional.py
@@ -1,0 +1,54 @@
+import importlib.util
+import os
+import unittest
+
+
+class KVCacheBugfixOptionalTests(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        enabled = os.getenv("VOXMLX_ENABLE_MLX_RUNTIME_TESTS", "").strip().lower() in {
+            "1",
+            "true",
+            "yes",
+            "on",
+        }
+        if not enabled:
+            raise unittest.SkipTest(
+                "Set VOXMLX_ENABLE_MLX_RUNTIME_TESTS=1 to run MLX runtime optional tests"
+            )
+        if importlib.util.find_spec("mlx") is None:
+            raise unittest.SkipTest("mlx is required for runtime optional tests")
+
+    def test_concat_append_respects_max_size(self):
+        import mlx.core as mx
+
+        from voxmlx.cache import RotatingKVCache
+
+        cache = RotatingKVCache(max_size=8)
+        base = mx.arange(8, dtype=mx.float32).reshape(1, 1, 8, 1)
+        add = mx.array([100, 101, 102, 103], dtype=mx.float32).reshape(1, 1, 4, 1)
+
+        cache.update_and_fetch(base, base)
+        k, v = cache.update_and_fetch(add, add)
+
+        self.assertEqual(k.shape[2], 8)
+        self.assertEqual(v.shape[2], 8)
+
+    def test_oversized_first_update_trims_to_max_size(self):
+        import mlx.core as mx
+        import numpy as np
+
+        from voxmlx.cache import RotatingKVCache
+
+        cache = RotatingKVCache(max_size=4)
+        keys = mx.arange(7, dtype=mx.float32).reshape(1, 1, 7, 1)
+        values = mx.arange(7, dtype=mx.float32).reshape(1, 1, 7, 1)
+        k, v = cache.update_and_fetch(keys, values)
+
+        expected = mx.array([3, 4, 5, 6], dtype=mx.float32).reshape(1, 1, 4, 1)
+        np.testing.assert_allclose(np.array(k), np.array(expected), atol=0.0, rtol=0.0)
+        np.testing.assert_allclose(np.array(v), np.array(expected), atol=0.0, rtol=0.0)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/voxmlx/cache.py
+++ b/voxmlx/cache.py
@@ -5,10 +5,12 @@ class RotatingKVCache:
     step = 256
 
     def __init__(self, max_size):
+        if int(max_size) <= 0:
+            raise ValueError(f"max_size must be > 0, got {max_size!r}")
         self.keys = None
         self.values = None
         self._offset = 0
-        self.max_size = max_size
+        self.max_size = int(max_size)
         self._idx = 0
 
     @property
@@ -38,18 +40,29 @@ class RotatingKVCache:
 
     def _update_concat(self, keys, values):
         if self.keys is None:
-            self.keys = keys
-            self.values = values
+            add = keys.shape[2]
+            if add > self.max_size:
+                trim_size = add - self.max_size
+                self.keys = keys[..., trim_size:, :]
+                self.values = values[..., trim_size:, :]
+            else:
+                self.keys = keys
+                self.values = values
         else:
             self.keys = self._temporal_order(self.keys)
             self.values = self._temporal_order(self.values)
             self._idx = self.keys.shape[2]
 
-            trim_size = self._idx - self.max_size + 1
+            cur = self.keys.shape[2]
+            add = keys.shape[2]
+            trim_size = max(0, cur + add - self.max_size)
             self.keys = self._trim(trim_size, self.keys, keys)
             self.values = self._trim(trim_size, self.values, values)
         self._offset += keys.shape[2]
         self._idx = self.keys.shape[2]
+        if __debug__:
+            assert self.keys.shape[2] <= self.max_size
+            assert self.values.shape[2] <= self.max_size
         return self.keys, self.values
 
     def _update_in_place(self, keys, values):


### PR DESCRIPTION
## Bug fix: KV cache concat trim for multi-token appends

### Problem
`RotatingKVCache._update_concat()` trimmed as if each update appended exactly one token:

```py
trim_size = self._idx - self.max_size + 1
```

For `S>1` appends, cache length can exceed `max_size` and stay above cap.

### Resolution
- Compute trim from current length + appended length:
  - `trim_size = max(0, cur + add - self.max_size)`
- Handle oversized first update by trimming to the latest `max_size` positions.
- Validate `max_size > 0` in constructor.
- Add debug assertions ensuring key/value cache length never exceeds cap.

### Why this helps
This restores bounded-window semantics and prevents memory/context drift when updates append multiple tokens.

### Regression tests
- `tests/test_bugfix_kvcache_optional.py::test_concat_append_respects_max_size`
- `tests/test_bugfix_kvcache_optional.py::test_oversized_first_update_trims_to_max_size`

### How to run
```bash
VOXMLX_ENABLE_MLX_RUNTIME_TESTS=1 python3 -m unittest -v tests.test_bugfix_kvcache_optional
```
